### PR TITLE
Wrong relative path

### DIFF
--- a/doc/src/content/tutorial/essential/result/_index.md
+++ b/doc/src/content/tutorial/essential/result/_index.md
@@ -31,7 +31,7 @@ Now, we will define an enumeration describing different failure situations durin
 
 {{% snippet "using_result.cpp" "enum" %}}
 
-Assume we have plugged it into `std::error_code` framework, as described in [this section](../../../motivation/plug_error_code).
+Assume we have plugged it into `std::error_code` framework, as described in [this section](../../motivation/plug_error_code).
 
 One notable effect of such plugging is that `ConversionErrc` is now convertible to `std::error_code`.
 Now we can implement function `convert` as follows:


### PR DESCRIPTION
This path was broken on the [boost docs](https://www.boost.org/doc/libs/1_73_0/libs/outcome/doc/html/tutorial/essential/result.html) and the [github pages docs](https://boostorg.github.io/outcome/tutorial/essential/result.html).